### PR TITLE
NumPy 1.19.5 may not yet support Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.6"
 editdistance = "0.6.0"
-numpy = "1.19.5"
+numpy = "^1.19.5"
 gensim = "4.1.2"
 tabulate = "0.8.9"
 emoji = "1.6.3"


### PR DESCRIPTION
Update in Python Package NumPy