### PR TITLE
change syntax of the tool.poetry.dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,16 +12,16 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
-editdistance = "0.6.0"
-numpy = "^1.19.5"
-gensim = "4.1.2"
-tabulate = "0.8.9"
-emoji = "1.6.3"
+python = ">=3.6"
+editdistance = ">=0.6.0"
+numpy = ">=1.19.5"
+gensim = ">=4.1.2"
+tabulate = ">=0.8.9"
+emoji = ">=1.6.3"
 
 [tool.poetry.dev-dependencies]
-coveralls = "^3.3.1"
-pytest-cov = "^3.0.0"
+coveralls = ">=3.3.1"
+pytest-cov = ">=3.0.0"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
change syntax of the `tool.poetry.dependencies` to allow uptade the librarires to the new versions of python like 3.10